### PR TITLE
People page update

### DIFF
--- a/_people/michael.md
+++ b/_people/michael.md
@@ -7,6 +7,7 @@ status: current
 picture: /assets/images/michael_lim.jpg
 picture-link: https://www.linkedin.com/in/michaelhlim/
 header-link: https://www.linkedin.com/in/michaelhlim/
+research: POMDPs, Statistical Learning, Computer Vision, Robotics, Ecology
 ---
 
 I am a PhD student in Electrical Engineering and Computer Sciences - Control, Intelligent Systems, and Robotics (CIR) at UC Berkeley, grateful to be advised by Profs. Claire J. Tomlin and Zachary N. Sunberg. I am interested in developing autonomous systems and architectures that integrate learning, control, and planning to enable physical robots to operate intelligently, safely, and efficiently, with provable guarantees. Currently, my research approaches include:

--- a/_sass/people.scss
+++ b/_sass/people.scss
@@ -20,3 +20,18 @@
     margin: 0;
     padding: 0;
 }
+
+.person-info > h4 {
+    margin: 0;
+    margin-bottom: 0.25em;
+}
+
+.person-info > p {
+    margin: 0;
+}
+
+.person-section {
+    font-size: 12pt;
+    margin-top: 1em;
+    margin-bottom: 1.75em;
+}

--- a/people.md
+++ b/people.md
@@ -47,13 +47,33 @@ toc_sticky: true
     <a href="mailto:{{ person.email }}">{{ person.email }}</a></p>
 </div>
 </div>
-<div class="person-bio">
-    <p>{{ person.excerpt | markdownify }}</p>
+{% if person.program == "Faculty Member" %}
+<div class="person-section">
+    <summary><b>Detailed Bio</b></summary>
+    <div class="person-bio">
+        <p>{{ person.excerpt | markdownify }}</p>
+    </div>
 </div>
+{% else %}
+<div class="person-section">
+    <summary><b>Research Interests:</b> {{ person.research | markdownify }}</summary>
+<details>
+    <summary><b>Detailed Bio</b></summary>
+    <div class="person-bio">
+        <p>{{ person.excerpt | markdownify }}</p>
+    </div>
+</details>
+
+</div>
+{% endif %}
+<!-- <div class="person-bio">
+    <p>{{ person.excerpt | markdownify }}</p>
+</div> -->
 </div>
 {% endif %}
 {% endfor %}
 {% endfor %}
+<br>
 
 # Alumni
 
@@ -80,10 +100,13 @@ toc_sticky: true
 {{ person.name }}
 {% endif %}
 </h4>
-    <p>{{ person.program }}<br>
-    Position after ADCL: {{ person.first-destination }}</p>
+<p>{{ person.program }}</p>
 </div>
 </div>
+<div class="person-section">
+    <p><b>Position after ADCL</b>: <br>{{ person.first-destination }}</p>
+</div>
+
 </div>
 {% endif %}
 {% endfor %}

--- a/people.md
+++ b/people.md
@@ -51,24 +51,22 @@ toc_sticky: true
 <div class="person-section">
     <summary><b>Detailed Bio</b></summary>
     <div class="person-bio">
-        <p>{{ person.excerpt | markdownify }}</p>
+        <p>{{ person.excerpt | markdownify | remove: '<p>' | remove: '</p>' }}</p>
     </div>
 </div>
 {% else %}
 <div class="person-section">
-    <summary><b>Research Interests:</b> {{ person.research | markdownify }}</summary>
-<details>
-    <summary><b>Detailed Bio</b></summary>
-    <div class="person-bio">
-        <p>{{ person.excerpt | markdownify }}</p>
-    </div>
-</details>
-
+    {% if person.research != blank %}
+    <summary><b>Research Interests:</b> {{ person.research | markdownify | remove: '<p>' | remove: '</p>' }}</summary>
+    {% endif %}
+    <details>
+        <summary><b>Detailed Bio</b></summary>
+        <div class="person-bio">
+            <p>{{ person.excerpt | markdownify | remove: '<p>' | remove: '</p>' }}</p>
+        </div>
+    </details>
 </div>
 {% endif %}
-<!-- <div class="person-bio">
-    <p>{{ person.excerpt | markdownify }}</p>
-</div> -->
 </div>
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
## Updates
- Fixed centering issue for names and positions
- Added research interests field (won't show if it doesn't exist by default)
- Converted Detailed Bio into dropdown menu for all students
- Changed formatting for Alumni position to be below the entry instead of on the side

## Examples
**Before:**
![Screen Shot 2023-01-25 at 1 56 10 PM](https://user-images.githubusercontent.com/5422392/214700749-ce36b7b1-d9c5-4982-949e-4274d076112f.png)
- Name and position not centered
- Bio shown as default for everyone

**After:**
![Screen Shot 2023-01-25 at 1 56 21 PM](https://user-images.githubusercontent.com/5422392/214700922-cde829d0-a051-476b-b831-ff93810814a6.png)
