### PR TITLE
Add IROS 2026 target interception paper

### DIFF
--- a/bibliography/our-pubs.bib
+++ b/bibliography/our-pubs.bib
@@ -1,5 +1,14 @@
 % Add new publications at top
 
+@inproceedings{gupta2026beyond,
+    author={Himanshu Gupta and Kelvin Aladum and Nisar Ahmed and Bradley Hayes and Zachary N. Sunberg},
+    author+an={1=student,phd; 5=zach},
+    title={Beyond Fixed Goal Delivery: Online {POMDP} Planning for Target Interception in Crowds},
+    booktitle={{IEEE/RSJ} International Conference on Intelligent Robots and Systems ({IROS})},
+    year={2026},
+    url={https://tic-planning.github.io/}
+}
+
 @article{ray2026multimodal,
     author={Hunter Ray and Bijan Jourabchi and Zakariya Laouar and Benjamin Kraske and Zachary Sunberg and Nisar Ahmed},
     author+an={5=zach; 3=student,phd; 4=student,phd},


### PR DESCRIPTION
Adds “Beyond Fixed Goal Delivery: Online POMDP Planning for Target
Interception in Crowds” to the lab publications page.

Closes #68